### PR TITLE
Localstack Support: add way to change an AWS endpoint to custom

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,3 +157,11 @@ When you installed `awsmeter` using **jmeter-plugins** and executed JMeter with 
 ![Screenshot](https://raw.githubusercontent.com/JoseLuisSR/awsmeter/main/doc/img/awsmeter-compiled-issue.png)
 
 To fix it, please install Java 11 and execute JMeter with this version or install `awsmeter` following the steps described in the [Install](https://github.com/JoseLuisSR/awsmeter#install) section and execute JMeter with th version of Java you have (minimum 8). 
+
+# Localstack Support
+If you need to use the Localstack instead of real AWS - you should change **aws_endpoint_custom** parameter in plugin GUI from empty stirng to some URL of your Localstack instance (with Localstack Edge port)
+
+To avoid a problem with SSL validation - please add SSL certificate of your Localstack to JVM cacerts:
+```
+keytool -alias ANY_NAME -import -keystore "%JAVA_HOME%\lib\security\cacerts" -file some_localstack_selfsigned_certificate.crt
+```

--- a/src/main/java/org/apache/jmeter/protocol/aws/AWSClient.java
+++ b/src/main/java/org/apache/jmeter/protocol/aws/AWSClient.java
@@ -88,6 +88,18 @@ public interface AWSClient {
     }
 
     /**
+     * Get custom AWS endpoint from input of JMeter Java Request parameter.
+     * @param credentials
+     *        Represents the input of JMeter Java Request parameters.
+     * @return AWS endpoint String.
+     */
+    default String getAWSEndpoint(Map<String, String> credentials){
+        return Optional.ofNullable(credentials.get(AWSSampler.AWS_ENDPOINT_CUSTOM))
+                .filter(Predicate.not(String::isEmpty))
+                .orElse("");
+    }
+
+    /**
      * Function to get DefaultAwsRegionProviderChain from profile file.
      */
     Function<Map<String, String>, DefaultAwsRegionProviderChain> getDefaultAwsRegionProviderChain = credentials ->

--- a/src/main/java/org/apache/jmeter/protocol/aws/cognito/CognitoProducerSampler.java
+++ b/src/main/java/org/apache/jmeter/protocol/aws/cognito/CognitoProducerSampler.java
@@ -91,7 +91,7 @@ public abstract class CognitoProducerSampler extends AWSSampler implements AWSCl
      */
     @Override
     public SdkClient createSdkClient(Map<String, String> credentials) {
-        return CognitoIdentityProviderClient.builder()
+        return wrapClientForLocalstack(CognitoIdentityProviderClient.builder(), getAWSEndpoint(credentials))
                 .region(Region.of(getAWSRegion(credentials)))
                 .credentialsProvider(getAwsCredentialsProvider(credentials))
                 .build();

--- a/src/main/java/org/apache/jmeter/protocol/aws/kinesis/KinesisProducerSampler.java
+++ b/src/main/java/org/apache/jmeter/protocol/aws/kinesis/KinesisProducerSampler.java
@@ -73,7 +73,7 @@ public class KinesisProducerSampler extends AWSSampler implements AWSClientSDK2 
      */
     @Override
     public SdkClient createSdkClient(Map<String, String> credentials) {
-        return KinesisClient.builder()
+        return wrapClientForLocalstack(KinesisClient.builder(), getAWSEndpoint(credentials))
                 .region(Region.of(getAWSRegion(credentials)))
                 .credentialsProvider(getAwsCredentialsProvider(credentials))
                 .build();

--- a/src/main/java/org/apache/jmeter/protocol/aws/sns/SNSProducerSampler.java
+++ b/src/main/java/org/apache/jmeter/protocol/aws/sns/SNSProducerSampler.java
@@ -76,9 +76,9 @@ public abstract class SNSProducerSampler extends AWSSampler implements AWSClient
      */
     @Override
     public AwsSyncClientBuilder createAWSClient(Map<String, String> credentials) {
-        return AmazonSNSClient.builder()
-                .withCredentials(getAWSCredentialsProvider(credentials))
-                .withRegion(Regions.fromName(getAWSRegion(credentials)));
+        String awsRegion = getAWSRegion(credentials);
+        return wrapClientForLocalstack(AmazonSNSClient.builder(), getAWSEndpoint(credentials), awsRegion)
+                .withCredentials(getAWSCredentialsProvider(credentials));
     }
 
     /**

--- a/src/main/java/org/apache/jmeter/protocol/aws/sqs/SQSProducerSampler.java
+++ b/src/main/java/org/apache/jmeter/protocol/aws/sqs/SQSProducerSampler.java
@@ -84,7 +84,7 @@ public abstract class SQSProducerSampler extends AWSSampler implements AWSClient
      */
     @Override
     public SdkClient createSdkClient(Map<String, String> credentials) {
-        return SqsClient.builder()
+        return wrapClientForLocalstack(SqsClient.builder(), getAWSEndpoint(credentials))
                 .region(Region.of(getAWSRegion(credentials)))
                 .credentialsProvider(getAwsCredentialsProvider(credentials))
                 .build();


### PR DESCRIPTION
## Problem
- no any way to use this plugin in case of Localstack environment (instead of real AWS)

## Solution
- add a new parameter called ```aws_endpoint_custom```
- - real AWS integration will be used if this parameter has empty value (**by default**)
- - custom (e.g. Localstack) endpoint will be used instead of real AWS if you will use some URL as value for this parameter